### PR TITLE
Make theme code snippet CE friendly

### DIFF
--- a/devGuide/en/chapters/04-theme-development.markdown
+++ b/devGuide/en/chapters/04-theme-development.markdown
@@ -380,7 +380,7 @@ content:
 
     <look-and-feel>
 		<compatibility>
-			<version>6.1.10+</version>
+			<version>6.1.1+</version>
 		</compatibility>
 		<theme id="deep-blue" name="Deep Blue">
 			<settings>


### PR DESCRIPTION
The 6.1.10+ version only works for Liferay EE GA2. I changed the version to be compatible with Liferay CE GA2 (as requested in LRDOCS-343).

https://issues.liferay.com/browse/LRDOCS-343
