### PR TITLE
LRDOCS-495.

### DIFF
--- a/devGuide/en/chapters/02-tools-and-dev.markdown
+++ b/devGuide/en/chapters/02-tools-and-dev.markdown
@@ -2393,8 +2393,9 @@ directory structure:
                 - view.jsp
     - pom.xml
 
-The `portlet-plugin/src/main/java/` directory holds the portlet's Java source
-code (e.g., `com.liferay.sample.SamplePortlet.java`), and
+The `portlet-plugin/src/main/java/` directory is created automatically when you
+on create a portlet project with Maven. It holds the portlet's Java source code
+(e.g., `com.liferay.sample.SamplePortlet.java`), and
 `portlet-plugin/src/main/webapp` holds its web source code. If you've created
 any portlet plugins using the Plugins SDK, you might have noted it uses a
 different directory structure. 
@@ -2473,10 +2474,10 @@ directory structure:
                 - WEB-INF/
                     - liferay-plugin-package.properties
                     - web.xml
-                - css/
-                - images/
-                - js/
-                - templates/
+            - css/
+            - images/
+            - js/
+            - templates/
 
 Several of the directories listed in the structure above are not created
 automatically; you'll create them as needed, depending on the customizations


### PR DESCRIPTION
Explicitly noted that the src/main/java directory is created upon creation of the portlet plugin project using Maven. Also fixed and indentation problem in the Maven/Theme/Anatomy subsection. It appeared that the css, js, images, and template folders should be under src/main/webapp, when in the text we say they should be one level higher (src/main/js, for instance).
