### PR TITLE
Struts Action example fix

### DIFF
--- a/devGuide/en/chapters/10-hooks.markdown
+++ b/devGuide/en/chapters/10-hooks.markdown
@@ -532,8 +532,10 @@ Here's the current action in your portal's `struts-config.xml` file:
 1.  Navigate to your `example-hook/docroot/WEB-INF` folder and open
     `liferay-hook.xml`. 
 
-2.  Insert the following code before the closing `</hook>` tag:
+2.  Insert the following code between the `<hook>...</hook>` tags:
 
+		<portal-properties>portal.properties</portal-properties>
+		<custom-jsp-dir>/META-INF/custom_jsps</custom-jsp-dir>
         <struts-action>
             <struts-action-path>/portal/sample</struts-action-path>
             <struts-action-impl>


### PR DESCRIPTION
Hey Jim,

I had to add a couple additional lines to the `liferay-hook.xml`, but now the struts path is accessible from the browser. I can now run through the full Struts Action example successfully.

https://issues.liferay.com/browse/LRDOCS-792
