### PR TITLE
Auto-complete does not require space

### DIFF
--- a/develop/README.markdown
+++ b/develop/README.markdown
@@ -118,9 +118,8 @@ the `21-liferayui-taglibs` category folder.
     ant article-to-html-win -Darticle=articles/liferayui-taglibs/using-liferay-ui-success-and-error-messages.markdown
     ```
 
-    *Hint:* To leverage your terminal's auto-complete feature in typing out the
-    article path, leave a space between the `=` character and the article path.
-    You can always remove the space before running the command. 
+    *Hint:* You can leverage your terminal's auto-complete feature when
+    specifying the article path. 
 
 3.  The HTML file is produced to the corresponding folder under `build/` (e.g.,
 `build/articles/liferayui-taglibs/using-liferay-ui-success-and-error-messages.markdown.html`).


### PR DESCRIPTION
I've been using the auto-complete feature for generating HTML for our articles, and I noticed that I didn't have to insert a space between the `=` and `articles` to take advantage of auto-complete. Therefore, I edited the hint to only point out the helpfulness of using auto-complete, and removed the suggestion to add a space.
