### PR TITLE
JSF Validation Message Updates

### DIFF
--- a/devGuide/en/chapters/04-developing-jsf-portlets.markdown
+++ b/devGuide/en/chapters/04-developing-jsf-portlets.markdown
@@ -385,7 +385,34 @@ facelet, yet in this example we map EDIT mode to the /edit.xhtml facelet. This
 seems confusing. - Jim -->
 
 Now that we've considered how to implement portal preferences, let's learn how
-to access the Portlet API. 
+to give feedback to users with validation messages. 
+
+### Giving Feedback to Users with Validation Messages [](id=liferay-faces-portal-validation-messages-liferay-portal-6-2-dev-guide-en)
+
+Liferay Faces Bridge automatically applies JSR 286 standard CSS class names
+`portlet-msg-error`, `portlet-msg-info`, and `portlet-msg-warn` to the 
+[`h:message`](http://java.sun.com/javaee/javaserverfaces/1.2/docs/tlddocs/h/message.html)
+ and 
+[`h:messages`](http://java.sun.com/javaee/javaserverfaces/1.2/docs/tlddocs/h/messages.html)
+tags. 
+
+---
+
+ ![Note](../../images/tip.png) **Note:** When running as a portlet, the ICEfaces
+ [`ice:messages`](http://www.icefaces.org/docs/latest/tld/ice/messages.html) and
+ [`ice:message`](http://www.icefaces.org/docs/latest/tld/ice/message.html)
+ component tags automatically apply the JSR 286 standard class names too.
+ Additionally, the 
+ [`ice:dataTable`](http://www.icefaces.org/docs/latest/tld/ice/dataTable.html)
+ component tag applies the following JSR 286 standard class names for
+ alternating table rows: 
+
+ - `portlet-section-alternate`
+ - `portlet-section-body`
+
+---
+
+Next, you'll learn how to access the Portlet API. 
 
 ### Accessing the Portlet API with ExternalContext [](id=access-portlet-api-with-externalcontext-liferay-portal-6-2-dev-guide-en)
 
@@ -1812,31 +1839,6 @@ qualified URL to an icon image in the current Liferay theme. Additionally,
 Liferay Faces Portal provides the `liferay.themeImagesURL` and
 `liferay.themeImageURL` Facelet composite component tags for gaining access to
 theme image icons. 
-
-### Giving Feedback to Users with Validation Messages [](id=liferay-faces-portal-validation-messages-liferay-portal-6-2-dev-guide-en)
-
-Liferay Faces Bridge automatically applies JSR 286 standard CSS class names
-`portlet-msg-error`, `portlet-msg-info`, and `portlet-msg-warn` to the 
-[`h:message`](http://java.sun.com/javaee/javaserverfaces/1.2/docs/tlddocs/h/message.html)
- and 
-[`h:messages`](http://java.sun.com/javaee/javaserverfaces/1.2/docs/tlddocs/h/messages.html)
-tags. 
-
----
-
- ![Note](../../images/tip.png) **Note:** When running as a portlet, the ICEfaces
- [`ice:messages`](http://www.icefaces.org/docs/latest/tld/ice/messages.html) and
- [`ice:message`](http://www.icefaces.org/docs/latest/tld/ice/message.html)
- component tags automatically apply the JSR 286 standard class names too.
- Additionally, the 
- [`ice:dataTable`](http://www.icefaces.org/docs/latest/tld/ice/dataTable.html)
- component tag applies the following JSR 286 standard class names for
- alternating table rows: 
-
- - `portlet-section-alternate`
- - `portlet-section-body`
-
----
 
 Next, we'll look at using Liferay Faces Portal's language capabilities
 with JSF Portlets. 


### PR DESCRIPTION
This fix was submitted by Kyle Stiemann. Since validation messages no longer rely on the *Liferay Faces Portal* tag `liferay-ui:message`, I moved the section to a more appropriate spot. These edits are for the old Dev Guide.

I've updated the tutorial for LDN (in review: [LRDOCS-1216](https://issues.liferay.com/browse/LRDOCS-1216)) with this new info, which can be found on my branch [here](https://github.com/codyhoag/liferay-docs/blob/jsf-edits/develop/tutorials/articles/liferay-faces/giving-feedback-to-users-with-validation-messages.markdown).