### PR TITLE
LRDOCS-3710 Gradle credentials stored when using Installer

### DIFF
--- a/develop/tutorials/articles/100-tooling/04-liferay-workspace/01-installing-liferay-workspace.markdown
+++ b/develop/tutorials/articles/100-tooling/04-liferay-workspace/01-installing-liferay-workspace.markdown
@@ -29,6 +29,21 @@ Follow the steps below to download and install Liferay Workspace:
 
     ![Figure 2: Select the product version you'll use with your Liferay Workspace.](../../../images/installer-workspace-type.png)
 
+    +$$$
+
+    **Note:** You'll' be prompted for your liferay.com username and password
+    before downloading the Liferay DXP bundle. After providing your credentials,
+    they're stored in your `~/.gradle/gradle.properties` file. The credentials
+    are used by your workspace if you ever decide to redownload a DXP bundle.
+    Furthermore, the bundle that is downloaded in your workspace is also copied
+    to your `~/.liferay/bundles` folder, so if you decide to initialize another
+    @product@ instance of the same version, the bundle is not re-downloaded. See
+    the
+    [Adding a Liferay Bundle to a Workspace](/develop/tutorials/-/knowledge_base/7-0/adding-a-liferay-bundle-to-a-workspace)
+    for more information on this topic.
+
+    $$$
+
 5.  Click *Next* to begin installing Liferay Workspace on your machine.
 
 That's it! Liferay Workspace is now installed on your machine!


### PR DESCRIPTION
This information already resides in the [Installing Liferay Developer Studio](https://github.com/liferay/liferay-docs/blob/master/develop/tutorials/articles-dxp/100-tooling/02-liferay-ide/01-installing-liferay-ide.markdown) tutorial. I've added it here too, so users of the Workspace Installer are aware.

https://issues.liferay.com/browse/LRDOCS-3710