### PR TITLE
LRDOCS-3737 Rename Blade Samples Gradle folder

### DIFF
--- a/develop/reference/articles/12-project-templates/13-portlet-configuration-icon-template.markdown
+++ b/develop/reference/articles/12-project-templates/13-portlet-configuration-icon-template.markdown
@@ -61,5 +61,5 @@ The generated module is functional and is deployable to a @product@ instance. Th
 generated module, by default, creates a sample link in the Hello World portlet's
 Options menu. To build upon the generated app, modify the project by adding
 logic and additional files to the folders outlined above. You can visit the
-[blade.portlet.configuration.icon](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.portlet.configuration.icon)
+[blade.portlet.configuration.icon](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.portlet.configuration.icon)
 sample project for a more expanded sample of a portlet configuration icon.

--- a/develop/reference/articles/12-project-templates/15-portlet-toolbar-contributor-template.markdown
+++ b/develop/reference/articles/12-project-templates/15-portlet-toolbar-contributor-template.markdown
@@ -61,5 +61,5 @@ The generated module is functional and is deployable to a @product@ instance. To
 build upon the generated app, modify the project by adding logic and additional
 files to the folders outlined above. This generated project, by default, creates
 a new button on the Hello World portlet's toolbar. You can visit the
-[blade.portlet.toolbar.contributor](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.portlet.toolbar.contributor)
+[blade.portlet.toolbar.contributor](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.portlet.toolbar.contributor)
 sample project for a more expanded sample of a portlet toolbar contributor.

--- a/develop/reference/articles/12-project-templates/20-simulation-panel-entry-template.markdown
+++ b/develop/reference/articles/12-project-templates/20-simulation-panel-entry-template.markdown
@@ -62,7 +62,7 @@ like this
 The generated module is functional and is deployable to a @product@ instance. To
 build upon the generated app, modify the project by adding logic and additional
 files to the folders outlined above. You can visit the
-[blade.simulation.panel.app](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.simulation.panel.app)
+[blade.simulation.panel.app](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.simulation.panel.app)
 sample project for a more expanded sample of a control menu entry. Likewise, see
 the
 [Extending the Simulation Menu](/develop/tutorials/-/knowledge_base/7-0/extending-the-simulation-menu)

--- a/develop/reference/articles/12-project-templates/22-template-context-contributor-template.markdown
+++ b/develop/reference/articles/12-project-templates/22-template-context-contributor-template.markdown
@@ -57,7 +57,7 @@ like this
 The generated module is functional and is deployable to a @product@ instance. To
 build upon the generated app, modify the project by adding logic and additional
 files to the folders outlined above. You can visit the
-[blade.template.context.contributor](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.template.context.contributor)
+[blade.template.context.contributor](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.template.context.contributor)
 sample project for a more expanded sample of a template context contributor.
 Likewise, see the
 [Context Contributors](/develop/tutorials/-/knowledge_base/7-0/context-contributors)

--- a/develop/reference/articles/13-sample-modules/00-intro.markdown
+++ b/develop/reference/articles/13-sample-modules/00-intro.markdown
@@ -7,7 +7,7 @@ Github repository and can be easily copy/pasted to your local environment. The
 sample modules are grouped into three different parent folders based on the
 build tools used to generate them:
 
-- `liferay-gradle`
+- `gradle`
 - `liferay-workspace`
 - `maven`
 

--- a/develop/reference/articles/13-sample-modules/01-control-menu-entry.markdown
+++ b/develop/reference/articles/13-sample-modules/01-control-menu-entry.markdown
@@ -34,6 +34,6 @@ needs, see the Javadoc listed in this sample's
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.controlmenuentry)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.controlmenuentry)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.controlmenuentry)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.controlmenuentry)

--- a/develop/reference/articles/13-sample-modules/02-core-jsp-hook.markdown
+++ b/develop/reference/articles/13-sample-modules/02-core-jsp-hook.markdown
@@ -29,6 +29,6 @@ see the Javadoc listed in this sample's `BladeCustomJspBag` class.
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.corejsphook)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.corejsphook)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.corejsphook)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.corejsphook)

--- a/develop/reference/articles/13-sample-modules/03-document-action.markdown
+++ b/develop/reference/articles/13-sample-modules/03-document-action.markdown
@@ -41,6 +41,6 @@ There are four Java classes used in this sample:
 There are three different versions of this sample, each built with a different
 build tool:
    
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.document.action)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.document.action)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.document.action)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.document.action)

--- a/develop/reference/articles/13-sample-modules/04-language.markdown
+++ b/develop/reference/articles/13-sample-modules/04-language.markdown
@@ -50,6 +50,6 @@ portlet.
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.language)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.language)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.language)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.language)

--- a/develop/reference/articles/13-sample-modules/05-language-web.markdown
+++ b/develop/reference/articles/13-sample-modules/05-language-web.markdown
@@ -32,6 +32,6 @@ modules.
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.language.web)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.language.web)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.language.web)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.language.web)

--- a/develop/reference/articles/13-sample-modules/06-screen-name-validator.markdown
+++ b/develop/reference/articles/13-sample-modules/06-screen-name-validator.markdown
@@ -41,6 +41,6 @@ the Javadoc provided in this sample's Java classes.
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.screenname.validator)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.screenname.validator)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.screenname.validator)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.screenname.validator)

--- a/develop/reference/articles/13-sample-modules/07-spring-mvc-portlet.markdown
+++ b/develop/reference/articles/13-sample-modules/07-spring-mvc-portlet.markdown
@@ -26,6 +26,6 @@ class.
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.portlet.springmvc)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.portlet.springmvc)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/wars/blade.portlet.springmvc)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.portlet.springmvc)

--- a/develop/reference/articles/13-sample-modules/08-template-context-contributor.markdown
+++ b/develop/reference/articles/13-sample-modules/08-template-context-contributor.markdown
@@ -36,6 +36,6 @@ fit your needs, see the Javadoc listed in this sample's
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.template.context.contributor)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.template.context.contributor)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.template.context.contributor)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.template.context.contributor)

--- a/develop/reference/articles/13-sample-modules/09-theme-contributor.markdown
+++ b/develop/reference/articles/13-sample-modules/09-theme-contributor.markdown
@@ -45,6 +45,6 @@ but you can write whatever JavaScript you want:
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.theme.contributor)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.theme.contributor)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.theme.contributor)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.theme.contributor)

--- a/develop/reference/articles/13-sample-modules/10-theme.markdown
+++ b/develop/reference/articles/13-sample-modules/10-theme.markdown
@@ -23,6 +23,6 @@ files, see the
 There are three different versions of this sample, each built with a different
 build tool:
 
-- [Liferay Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.theme)
+- [Gradle](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.theme)
 - [Liferay Workspace](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-workspace/modules/blade.theme)
 - [Maven](https://github.com/liferay/liferay-blade-samples/tree/master/maven/blade.theme)

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/04-creating-modules-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/04-creating-modules-with-blade-cli.markdown
@@ -117,7 +117,7 @@ this, use the following syntax:
     blade samples <NAME>
 
 For example, if you wanted to generate the
-[blade.portlet.ds](https://github.com/liferay/liferay-blade-samples/tree/master/liferay-gradle/blade.portlet.ds)
+[blade.portlet.ds](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/blade.portlet.ds)
 sample, you could execute
 
     blade samples blade.portlet.ds

--- a/develop/tutorials/articles/100-tooling/07-liferay-sample-modules/00-liferay-sample-modules-intro.markdown
+++ b/develop/tutorials/articles/100-tooling/07-liferay-sample-modules/00-liferay-sample-modules-intro.markdown
@@ -21,19 +21,18 @@ own project, [fork](https://help.github.com/articles/fork-a-repo/) and
 At first glance, you'll notice that the repository is broken up into three
 primary folders:
 
-- `liferay-gradle`
+- `gradle`
 - `liferay-workspace`
 - `maven`
 
 The provided sample modules are organized by their development toolchains to
 cater to a variety of developers. Each folder offers the same set of sample
 Liferay modules. Their only difference is that the build files are specific to
-their toolchain. For example, the `liferay-gradle` folder contains projects
-using standard OSS Gradle plugins that can be added to any Gradle composite
-build. The same concept also applies to the `maven` and `liferay-workspace`
-projects.
+their toolchain. For example, the `gradle` folder contains projects using
+standard OSS Gradle plugins that can be added to any Gradle composite build. The
+same concept also applies to the `maven` and `liferay-workspace` projects.
 
-The `liferay-gradle` folder also uses the Liferay Gradle plugin (e.g.,
+The `gradle` folder also uses the Liferay Gradle plugin (e.g.,
 `com.liferay.plugin`) which encompasses additional functionality for various
 types of Liferay modules. The Liferay Gradle plugin is recommended for Gradle
 users developing for Liferay. 

--- a/develop/tutorials/articles/111-customizing/01-overriding-core-jsps.markdown
+++ b/develop/tutorials/articles/111-customizing/01-overriding-core-jsps.markdown
@@ -109,7 +109,7 @@ JSP paths. The `getResource` method returns one specific resource by its name
 -  **`isCustomJspGlobal`:** Return `true`.
 
 For an example of a full class that provides a working implementation of a
-custom JSP bag, refer to the [blade.corejsphook BLADE project](https://github.com/liferay/liferay-blade-samples/blob/master/liferay-gradle/blade.corejsphook/src/main/java/com/liferay/blade/samples/corejsphook/BladeCustomJspBag.java).
+custom JSP bag, refer to the [blade.corejsphook BLADE project](https://github.com/liferay/liferay-blade-samples/blob/master/gradle/blade.corejsphook/src/main/java/com/liferay/blade/samples/corejsphook/BladeCustomJspBag.java).
 
 ## Register the Custom JSP Bag [](id=register-the-custom-jsp-bag)
 


### PR DESCRIPTION
I've updated our links to point to the new `gradle` folder (renamed from `liferay-gradle`). Please publish at your earliest convenience. Thanks!

/cc @gamerson

https://issues.liferay.com/browse/LRDOCS-3735