### PR TITLE
LRDOCS-4728 Should we always use the term "Liferay DXP" now?

### DIFF
--- a/discover/deployment/articles/00-deploying-liferay/02-installing-liferay.markdown
+++ b/discover/deployment/articles/00-deploying-liferay/02-installing-liferay.markdown
@@ -61,7 +61,7 @@ Liferay Home has folders for various purposes:
         -   `target-platform`: Target platform index
         -   `test`: Modules that support test integration
         -   `war`: WAR plugins you've deployed
-    -   `patching-tool`: (Liferay Digital Enterprise 7.1 only) This folder 
+    -   `patching-tool`: (Liferay DXP 7.1 only) This folder 
         contains patches for @product@ and files for installing the patches.
     -   `tools`: For @product@ upgrade and target platform indexer.
     -   `work`: Module Jasper work files.


### PR DESCRIPTION
@jhinkey It seems we should always use Liferay DXP instead of Liferay Digital Enterprise. Could you confirm if this is the case? Thanks.