### PR TITLE
Update to deprecated definition, list of deprecated features

### DIFF
--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -17,11 +17,7 @@ There are three types of deprecated apps:
 2.  Deprecated apps that have been removed from @product@, yet are still 
     available for download via [Liferay
     Marketplace](https://web.liferay.com/marketplace) (Availability:
-    *Marketplace*) or [Liferay's public Nexus
-    repository](https://repository.liferay.com/nexus/index.html#view-repositories)
-    (Availability: *Nexus*). For instructions on installing apps, see the
-    [Managing Apps](/docs/7-2/user/-/knowledge_base/u/managing-apps)
-    documentation. 
+    *Marketplace*) 
 
 3.  Deprecated apps that have been removed from @product@ and aren't available 
     for download. (Availability: *Removed*) 
@@ -35,48 +31,40 @@ Here are the apps deprecated in @product-ver@.
 
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
-| Chat | TBD |  |
-| Directory | TBD |  |
-| Group Statistics | TBD |  |
-| Microblogs | TBD |  |
-| Quick Note | TBD |  |
-| Recently Downloaded | TBD |  |
-| Social Activity | TBD |  |
-| Social Networking | TBD | Formerly available as an unsupported Labs app via Marketplace. | 
-| User Statistics | TBD |  |
+| Bookmarks | Marketplace release planned |  |
 
 ## Foundation
 
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
 | AlloyUI | TBD | Replaced by [Metal.js](https://metaljs.com/). | 
-| Google Login | Marketplace | Replaced by [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 | JCRStore | Removed | Migrate to another [Document Repository Store option](/docs/7-2/deploy/-/knowledge_base/d/document-repository-configuration). Before [upgrading to @product-ver@](/docs/7-2/deploy/-/knowledge_base/d/upgrading-to-product-ver), migrate your document store data using [Data Migration in Server Administration](/docs/7-2/user/-/knowledge_base/u/server-administration). |
-| OpenID | Marketplace | Replaced by [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
-| Plugins SDK | Removed; 7.0 version on [GitHub](https://github.com/liferay/liferay-plugins) | Deprecated in 7.0. Replaced by [Liferay Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace).  |
-| Search Portlet | TBD | Will be removed in a future release. Replaced by the [Search widgets](/docs/7-1/user/-/knowledge_base/u/whats-new-with-search). |
-| Template Engines | TBD | Replaced by Freemarker. |
-| WYSIWYG | TBD [Nexus](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.wysiwyg.web/) &rarr; Will be removed. |  Final version released for 7.0. |
+| Search Portlet | Bundled | Will be removed in a future release. Replaced by the [Search widgets](/docs/7-1/user/-/knowledge_base/u/whats-new-with-search). |
+
+# Personalization
+| App |  Availability |  Notes |
+| --- | ------------- | ------ |
+| Audience Targeting | Removed | Replaced by Personalization in 7.2 | 
 
 ## Web Experience
 
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
-| RSS Publisher | TBD | See [the article](/docs/7-1/user/-/knowledge_base/u/the-rss-publisher-widget) on enabling and using this widget. |
+| RSS Publisher | Bundled | See [the article](/docs/7-1/user/-/knowledge_base/u/the-rss-publisher-widget) on enabling and using this widget. |
 | User Group Pages (Copy Mode) | TBD |  |
-| Web Proxy Portlet | TBD [Nexus](https://repository.liferay.com/nexus/service/local/repositories/liferay-public-releases/content/com/liferay/com.liferay.web.proxy.web/2.0.0/com.liferay.web.proxy.web-2.0.0.jar) |  |
-| Web Content Search Portlet | TBD [Nexus](https://repository.liferay.com/nexus/service/local/repositories/liferay-public-releases/content/com/liferay/com.liferay.journal.content.search.web/2.0.0/com.liferay.journal.content.search.web-2.0.0.jar) | The new Search widget can be configured to replace all the unique functionality of the Web Content Search |
 
 ## Forms and Workflow
 
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
-| Web Form | TBD | Final version released for 7.0. |
 
 ## Security
 
 | App |  Availability |  Notes |
 | --- | ------------------ | ----------- |
-| NTLM | Source code at `modules/apps/portal-security-sso-ntlm`. Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
-| OAuth 1.0a | Marketplace | Replaced by OAuth 2.0, which is included in the bundle. |
-| OpenID | Marketplace | [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+| Central Authentication Service | Bundled |   |
+| Google Login | Marketplace release planned | Replaced by [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+| NTLM | Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
+| OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
+| OpenAM / OpenSSO | Bundled |  |
+| OpenID | Marketplace release planned | [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |

--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -68,3 +68,8 @@ Here are the apps deprecated in @product-ver@.
 | OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
 | OpenAM / OpenSSO | Bundled |  |
 | OpenID | Marketplace release planned | [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+
+## User and System Management
+| App |  Availability |  Notes |
+| --- | ------------------ | ----------- |
+| Live Users | Enabled through Portal Properties |  |

--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -67,7 +67,7 @@ Here are the apps deprecated in @product-ver@.
 | NTLM | Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
 | OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
 | OpenAM / OpenSSO | Bundled |  |
-| OpenID | Marketplace release planned | [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+| OpenID | Marketplace release planned | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 
 ## User and System Management
 | App |  Availability |  Notes |

--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -63,7 +63,7 @@ Here are the apps deprecated in @product-ver@.
 | App |  Availability |  Notes |
 | --- | ------------------ | ----------- |
 | Central Authentication Service | Bundled |   |
-| Google Login | Marketplace release planned | Replaced by [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+| Google Login | Marketplace release planned | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 | NTLM | Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
 | OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
 | OpenAM / OpenSSO | Bundled |  |

--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -67,7 +67,7 @@ Here are the apps deprecated in @product-ver@.
 | NTLM | Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
 | OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
 | OpenAM / OpenSSO | Bundled |  |
-| OpenID | Marketplace release planned | [OpenID Connect]((/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
+| OpenID | Marketplace release planned | [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 
 ## User and System Management
 | App |  Availability |  Notes |


### PR DESCRIPTION
Features released in Nexus will be considered "Removed" now. 
All features that were listed as "Removed" or "Nexus" should not be on this list. 
Added Bookmarks, Audience targeting, CAS, OpenAM/Open SSO. 
Moved Google Login and OpenID to Security.