### PR TITLE
Added Maintenance Mode section

### DIFF
--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -1,3 +1,13 @@
+# Maintenance Mode
+
+Maintenance Mode for a product or capability means we are no longer actively enhancing the product or capability.  Liferay will continue to provide bug fixes and provide full support in accordance to with Subscribers' subscription level and the end of service life policies of the compatible DXP version. 
+
+## Products & Features in Maintenance Mode
+* Liferay Connected Services
+* Liferay Mobile Experience (Liferay Screens, Liferay Mobile SDK, Liferay Push)
+* Staging 
+* Liferay Sync
+
 # Deprecated Apps in 7.2: What to Do 
 
 [TOC levels=1-4]
@@ -48,20 +58,20 @@ Here are the apps deprecated in @product-ver@.
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
 | RSS Publisher | Bundled | See [the article](/docs/7-1/user/-/knowledge_base/u/the-rss-publisher-widget) on enabling and using this widget. |
-| User Group Pages (Copy Mode) | TBD |  |
+| User Group Pages (Copy Mode) | Bundled | See the [Legacy User Group Sites Behavior article] for instructions on how to enable. |
 
 ## Security
 
 | App |  Availability |  Notes |
 | --- | ------------------ | ----------- |
-| Central Authentication Service | Bundled |   |
+| Central Authentication Service | Bundled | Migrate to SAML based authentication |
 | Google Login | Marketplace release planned | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
-| NTLM | Marketplace release planned. | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
-| OAuth 1.0a | Marketplace release planned. | Replaced by OAuth 2.0, which is included in the bundle. |
-| OpenAM / OpenSSO | Bundled |  |
+| NTLM | Marketplace release planned | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
+| OAuth 1.0a | Marketplace release planned | Replaced by OAuth 2.0, which is included in the bundle. |
+| OpenAM / OpenSSO | Bundled | Migrate to SAML based authentication |
 | OpenID | Marketplace release planned | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 
 ## User and System Management
-| App |  Availability |  Notes |
-| --- | ------------------ | ----------- |
-| Live Users | Enabled through Portal Properties |  |
+| App |  Availability | 
+| --- | ------------------ |
+| Live Users | Enabled through Portal Properties | 

--- a/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/99-deprecated-apps-in-7-2-what-to-do.markdown
@@ -48,7 +48,7 @@ Here are the apps deprecated in @product-ver@.
 | JCRStore | Removed | Migrate to another [Document Repository Store option](/docs/7-2/deploy/-/knowledge_base/d/document-repository-configuration). Before [upgrading to @product-ver@](/docs/7-2/deploy/-/knowledge_base/d/upgrading-to-product-ver), migrate your document store data using [Data Migration in Server Administration](/docs/7-2/user/-/knowledge_base/u/server-administration). |
 | Search Portlet | Bundled | Will be removed in a future release. Replaced by the [Search widgets](/docs/7-1/user/-/knowledge_base/u/whats-new-with-search). |
 
-# Personalization
+## Personalization
 | App |  Availability |  Notes |
 | --- | ------------- | ------ |
 | Audience Targeting | Removed | Replaced by Personalization in 7.2 | 


### PR DESCRIPTION
@jhinkey - Made a few more edits. 
Added Maintenance Mode section

Missing links for: 
* AT upgrade:  I don't think this documentation is complete - should we link to Personalization sections instead?
* User Group Pages: 7.1 doc link - https://dev.liferay.com/en/discover/portal/-/knowledge_base/7-1/user-group-sites#legacy-user-group-sites-behavior
* Live Users: I'm not sure where the documentation is.

Also, should the TOC be moved to the top?