### PR TITLE
LRDOCS-7052 fix broken links in dev reference

### DIFF
--- a/developer/reference/articles/back-end/03-portlet-descriptor-to-osgi-service-property-map.markdown
+++ b/developer/reference/articles/back-end/03-portlet-descriptor-to-osgi-service-property-map.markdown
@@ -30,7 +30,7 @@ property names resemble the original descriptor names.
 
 This article covers these descriptor mappings:
 
--   [Portlet descriptor mappings](#jsr-168-jsr-286-descriptor-mappings)
+-   [Portlet descriptor mappings](#portlet-descriptor-mappings)
 
 -   [Liferay descriptor mappings](#liferay-descriptor-mappings)
 

--- a/developer/reference/articles/cdi-portlet-predefined-beans.markdown
+++ b/developer/reference/articles/cdi-portlet-predefined-beans.markdown
@@ -29,7 +29,7 @@ or JSF page.
 implementation. 
 
 **Valid during (phase):** The 
-[portlet phases](/docs/7-2/frameworks/-/knowledge_base/f/cdi-dependency-injection/portlets)
+[portlet phases](/docs/7-2/frameworks/-/knowledge_base/f/portlets)
 in which the bean is valid. 
 
 ## Portlet Request Scoped Beans

--- a/developer/reference/articles/front-end/03-front-end-taglibs/02-liferay-ui-taglibs/06-liferay-ui-icon-help.markdown
+++ b/developer/reference/articles/front-end/03-front-end-taglibs/02-liferay-ui-taglibs/06-liferay-ui-icon-help.markdown
@@ -34,7 +34,7 @@ clean up actions:
 ![Figure 2: help icons are used throughout the Control Panel.](../../../../images/liferay-ui-taglib-tooltip-02.png)
 
 Note that the message is supplied via a 
-[language key](/docs/7-2/frameworks/-/knowledge_base/f/localizing-your-application#where-do-i-put-language-files). 
+[language key](/docs/7-2/frameworks/-/knowledge_base/f/localizing-your-application). 
 While you can use a string for the tooltip's message for testing purposes, a 
 language key is considered best practice and should be used in production. 
 

--- a/developer/reference/articles/front-end/03-front-end-taglibs/03-liferay-frontend-taglibs/05-liferay-frontend-management-bar/02-including-actions-in-the-management-bar.markdown
+++ b/developer/reference/articles/front-end/03-front-end-taglibs/03-liferay-frontend-taglibs/05-liferay-frontend-management-bar/02-including-actions-in-the-management-bar.markdown
@@ -60,5 +60,5 @@ Follow these steps to include actions in your management bar:
 
 ## Related Topics
 
-- [Disabling All or Portions of the Management Bar](/docs/7-2/frameworks/-/knowledge_base/f/disabling-all-or-portions-of-the-management-bar)
+- [Disabling All or Portions of the Management Bar](/docs/7-2/reference/-/knowledge_base/r/disabling-all-or-portions-of-the-management-bar)
 - [Clay Management Toolbar](/docs/7-2/reference/-/knowledge_base/r/clay-management-toolbar)

--- a/developer/reference/articles/front-end/03-front-end-taglibs/03-liferay-frontend-taglibs/05-liferay-frontend-management-bar/03-disabling-the-management-bar.markdown
+++ b/developer/reference/articles/front-end/03-front-end-taglibs/03-liferay-frontend-taglibs/05-liferay-frontend-management-bar/03-disabling-the-management-bar.markdown
@@ -38,5 +38,5 @@ effect when there aren't any results to view:
 
 ## Related Topics
 
-- [Including Actions in the Management Bar](/docs/7-2/frameworks/-/knowledge_base/f/including-actions-in-the-management-bar)
+- [Including Actions in the Management Bar](/docs/7-2/reference/-/knowledge_base/r/including-actions-in-the-management-bar)
 - [Clay Management Toolbar](/docs/7-2/reference/-/knowledge_base/r/clay-management-toolbar)

--- a/developer/reference/articles/front-end/03-front-end-taglibs/07-aui-taglibs/02-building-forms-with-aui-tags.markdown
+++ b/developer/reference/articles/front-end/03-front-end-taglibs/07-aui-taglibs/02-building-forms-with-aui-tags.markdown
@@ -125,5 +125,5 @@ Now you know how to build user-friendly forms for your applications.
 ## Related Topics
 
 - [Using the Chart Taglib in Your Portlets](/docs/7-2/reference/-/knowledge_base/r/using-the-chart-taglib-in-your-portlets)
-- [Using Liferay Front-end Taglibs in Your Portlet](/docs/7-2/reference/-/knowledge_base/r/using-liferay-frontend-taglibs-in-your-portlet)
+- [Using Liferay Front-end Taglibs in Your Portlet](/docs/7-2/reference/-/knowledge_base/r/using-liferay-front-end-taglibs-in-your-portlet)
 - [Using the Clay Taglib in Your portlets](/docs/7-2/reference/-/knowledge_base/r/using-the-clay-taglib-in-your-portlets)

--- a/developer/reference/articles/front-end/05-liferay-js-apis/05-invoking-liferay-services.markdown
+++ b/developer/reference/articles/front-end/05-liferay-js-apis/05-invoking-liferay-services.markdown
@@ -8,11 +8,15 @@ header-id: invoking-liferay-services
 
 @product@ provides many web services out-of-the-box. To see a comprehensive list 
 of the available web services, navigate to `http://localhost:8080/api/jsonws` 
-(assuming your localhost is running on port 8080). If you've deployed your own 
+(assuming your localhost is running on port 8080). 
+
+<!--Uncomment once registering-json-web-services#mapping-and-naming-conventions article is available
+If you've deployed your own 
 Service Builder-generated JSON web services, 
-[follow these guidelines](/docs/7-2/appdev/-/knowledge_base/a/registering-json-web-services#mapping-and-naming-conventions)
+follow these guidelines
 for invoking them. These services are useful for creating single page 
 applications and can even be used to create custom front-ends in @product@. 
+-->
 
 This reference covers how to invoke these web services using JavaScript. 
 

--- a/developer/reference/articles/gradle-plugins/app-docker-gradle-plugin.markdown
+++ b/developer/reference/articles/gradle-plugins/app-docker-gradle-plugin.markdown
@@ -82,8 +82,8 @@ Name | Depends On | Type | Description
 [`buildAppDockerImage`](#task-buildappdockerimage) | `prepareAppDockerImageInputDir` | [`DockerBuildImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.html) | Builds the app's Docker image.
 [`prepareAppDockerImageInputDir`](#task-prepareappdockerimageinputdir) | \- | [`Sync`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Sync.html) | Copies the subproject artifacts and other resources to a temporary directory that will be used to build the app's Docker image.
 [`pushAppDockerImage`](#task-pushappdockerimage) | `buildAppDockerImage`, `pushAppDockerImage_tag1`, `pushAppDockerImage_tag2`, ... | [`DockerPushImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html) | Pushes the app's Docker image to the registry.
-[`pushAppDockerImage_${tag}`](#tasks-pushappdockerimagetag) | `tagAppDockerImage_${tag}` | [`DockerPushImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html) | Pushes the Docker image `${tag}` to the registry.
-[`tagAppDockerImage_${tag}`](#tasks-tagappdockerimagetag) | `buildAppDockerImage` | [`DockerTagImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerTagImage.html) | Creates the tag `${tag}`, which refers to the app's Docker image.
+[`pushAppDockerImage_${tag}`](#tasks-pushappdockerimage-) | `tagAppDockerImage_${tag}` | [`DockerPushImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html) | Pushes the Docker image `${tag}` to the registry.
+[`tagAppDockerImage_${tag}`](#tasks-tagappdockerimage-) | `buildAppDockerImage` | [`DockerTagImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerTagImage.html) | Creates the tag `${tag}`, which refers to the app's Docker image.
 
 ### Task buildAppDockerImage
 

--- a/developer/reference/articles/gradle-plugins/lang-builder-gradle-plugin.markdown
+++ b/developer/reference/articles/gradle-plugins/lang-builder-gradle-plugin.markdown
@@ -43,7 +43,7 @@ repositories {
 }
 ```
 
-See [this page](/docs/7-2/customization/-/knowledge_base/c/automatically-generating-language-files)
+See [this page](/docs/7-2/frameworks/-/knowledge_base/f/automatically-generating-translations)
 on the *Liferay Developer Network* for more information about usage of the Lang
 Builder Gradle plugin.
 

--- a/developer/reference/articles/gradle-plugins/service-builder-gradle-plugin.markdown
+++ b/developer/reference/articles/gradle-plugins/service-builder-gradle-plugin.markdown
@@ -7,7 +7,7 @@ header-id: service-builder-gradle-plugin
 [TOC levels=1-4]
 
 The Service Builder Gradle plugin lets you generate a service layer defined in a
-[Service Builder](/docs/7-2/frameworks/-/knowledge_base/f/what-is-service-builder)
+[Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
 `service.xml` file.
 
 The plugin has been successfully tested with Gradle 4.10.2.
@@ -73,12 +73,17 @@ Property Name | Default Value
 [`springFile`](#springfile) | <p>**If `osgiModule` is `true`:** the file `META-INF/spring/module-spring.xml` in the first `resources` directory of the `main` source set (by default: `src/main/resources/META-INF/spring/module-spring.xml`)</p><p>**Otherwise:** the file `META-INF/portlet-spring.xml` in the first `resources` directory of the `main` source set (by default: `src/main/resources/META-INF/portlet-spring.xml`)</p>
 [`sqlDir`](#sqldir) | <p>**If the `war` plugin is applied:** `${project.webAppDir}/WEB-INF/sql`</p><p>**Otherwise:** The directory `META-INF/sql` in the first `resources` directory of the `main` source set (by default: `src/main/resources/META-INF/sql`).</p>
 
-In the [typical scenario](/docs/7-2/frameworks/-/knowledge_base/f/defining-an-object-relational-map-with-service-builder)
-of a data-driven Liferay OSGi application split in `myapp-app`, `myapp-service`
-and `myapp-web` modules, the `service.xml` file is usually contained in the root
-directory of `myapp-service`. In the `build.gradle` of the same module, it is
-enough to apply the `com.liferay.service.builder` plugin [as described](#usage),
-and then add the following snippet to enable the use of Liferay Service Builder:
+<!--Add back link below for `typlical scenario` once 
+defining-an-object-relational-map-with-service-builder 
+article is available
+-->
+
+In the typical scenario of a data-driven Liferay OSGi application split in 
+`myapp-app`, `myapp-service` and `myapp-web` modules, the `service.xml` file is 
+usually contained in the root directory of `myapp-service`. In the 
+`build.gradle` of the same module, it is enough to apply the 
+`com.liferay.service.builder` plugin [as described](#usage), and then add the 
+following snippet to enable the use of Liferay Service Builder:
 
 ```gradle
 buildService {
@@ -118,7 +123,7 @@ Property Name | Type | Default Value | Description
 <a name="hbmfile"></a>`hbmFile` | `File` | `null` | A Hibernate Mapping file to generate. It sets the `service.hbm.file` argument.
 <a name="impldir"></a>`implDir` | `File` | `null` | A directory where the service Java source files are generated. It sets the `service.impl.dir` argument.
 <a name="inputfile"></a>`inputFile` | `File` | `null` | The project's `service.xml` file. It sets the `service.input.file` argument.
-`modelHintsConfigs` | `Set` | `["classpath*:META-INF/portal-model-hints.xml", "META-INF/portal-model-hints.xml", "classpath*:META-INF/ext-model-hints.xml", "classpath*:META-INF/portlet-model-hints.xml"]` | Paths to the [model hints](/docs/7-2/frameworks/-/knowledge_base/f/customizing-model-entities-with-model-hints) files for Liferay Service Builder to use in generating the service layer. It sets the `service.model.hints.configs` argument.
+`modelHintsConfigs` | `Set` | `["classpath*:META-INF/portal-model-hints.xml", "META-INF/portal-model-hints.xml", "classpath*:META-INF/ext-model-hints.xml", "classpath*:META-INF/portlet-model-hints.xml"]` | Paths to the model hints files for Liferay Service Builder to use in generating the service layer. It sets the `service.model.hints.configs` argument.<!-- Add back link for 'modal hints' once customizing-model-entities-with-model-hints article is available -->
 <a name="modelhintsfile"></a>`modelHintsFile` | `File` | `null` | A model hints file for the project. It sets the `service.model.hints.file` argument.
 <a name="osgimodule"></a>`osgiModule` | `boolean` | `false` | Whether to generate the service layer for OSGi modules. It sets the `service.osgi.module` argument.
 <a name="pluginname"></a>`pluginName` | `String` | `null` | If specified, a plugin can enable additional generation features, such as `Clp` class generation, for non-OSGi modules. It sets the `service.plugin.name` argument.

--- a/developer/reference/articles/gradle-plugins/wsdd-builder-gradle-plugin.markdown
+++ b/developer/reference/articles/gradle-plugins/wsdd-builder-gradle-plugin.markdown
@@ -8,7 +8,7 @@ header-id: wsdd-builder-gradle-plugin
 
 The WSDD Builder Gradle plugin lets you run the [Liferay WSDD Builder](https://github.com/liferay/liferay-portal/tree/master/modules/util/portal-tools-wsdd-builder)
 tool to generate the [Apache Axis](http://axis.apache.org/axis/) Web Service
-Deployment Descriptor (WSDD) files from a [Service Builder](/docs/7-2/frameworks/-/knowledge_base/f/what-is-service-builder)
+Deployment Descriptor (WSDD) files from a [Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
 `service.xml` file.
 
 The plugin has been successfully tested with Gradle 4.10.2.

--- a/developer/reference/articles/item-selector-criterion-and-return-types.markdown
+++ b/developer/reference/articles/item-selector-criterion-and-return-types.markdown
@@ -38,7 +38,7 @@ Blogs item.
 **Page Fragments:**
 
 [FragmentItemSelectorCriterion](@app-ref@/fragment/latest/javadocs/com/liferay/fragment/item/selector/criterion/FragmentItemSelectorCriterion.html): 
-[Page fragment](/docs/7-2/frameworks/-/knowledge_base/f/developing-fragments). 
+[Page fragment](/docs/7-2/frameworks/-/knowledge_base/f/page-fragments). 
 
 **Item Selector:**
 

--- a/developer/reference/articles/maven-plugins/service-builder-plugin.markdown
+++ b/developer/reference/articles/maven-plugins/service-builder-plugin.markdown
@@ -7,7 +7,7 @@ header-id: service-builder-plugin
 [TOC levels=1-4]
 
 The Service Builder plugin lets you generate a service layer defined in a
-[Service Builder](/docs/7-2/frameworks/-/knowledge_base/f/what-is-service-builder)
+[Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
 `service.xml` file. Visit the
 [Using Service Builder in a Maven Project](/docs/7-2/reference/-/knowledge_base/r/using-service-builder-in-a-maven-project)
 tutorial to learn more about applying Service Builder to your Maven project.
@@ -60,7 +60,7 @@ Parameter Name | Type | Default Value | Description
 `hbmFileName` | `String` | `"src/META-INF/portal-hbm.xml"` | A Hibernate Mapping file to generate.
 `implDirName` | `String` | `"src"` | A directory where the service Java source files are generated.
 `inputFileName` | `String` | `"service.xml"` | The project's `service.xml` file.
-`modelHintsConfigs` | `String` | `"classpath*:META-INF/portal-model-hints.xml, META-INF/portal-model-hints.xml, classpath*:META-INF/ext-model-hints.xml, classpath*:META-INF/portlet-model-hints.xml"` | Paths to the [model hints](/docs/7-2/frameworks/-/knowledge_base/f/customizing-model-entities-with-model-hints) files for Liferay Service Builder to use in generating the service layer.
+`modelHintsConfigs` | `String` | `"classpath*:META-INF/portal-model-hints.xml, META-INF/portal-model-hints.xml, classpath*:META-INF/ext-model-hints.xml, classpath*:META-INF/portlet-model-hints.xml"` | Paths to the model hints files for Liferay Service Builder to use in generating the service layer. <!-- Add back link for 'model hints' once article is available -->
 `modelHintsFileName` | `String` | `"src/META-INF/portal-model-hints.xml"` | A model hints file for the project.
 `osgiModule` | `boolean` | `null` | Whether to generate the service layer for OSGi modules.
 `pluginName` | `String` | `null` | If specified, a plugin can enable additional generation features, such as `Clp` class generation, for non-OSGi modules.

--- a/developer/reference/articles/maven-plugins/wsdd-builder-plugin.markdown
+++ b/developer/reference/articles/maven-plugins/wsdd-builder-plugin.markdown
@@ -9,7 +9,7 @@ header-id: wsdd-builder-plugin
 The WSDD Builder plugin lets you generate the
 [Apache Axis](http://axis.apache.org/axis/) Web Service Deployment Descriptor
 (WSDD) files from a
-[Service Builder](/docs/7-2/frameworks/-/knowledge_base/f/what-is-service-builder)
+[Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
 `service.xml` file.
 
 ## Usage

--- a/developer/reference/articles/project-templates/control-menu-entry-template.markdown
+++ b/developer/reference/articles/project-templates/control-menu-entry-template.markdown
@@ -81,7 +81,4 @@ The generated module is functional and is deployable to a @product@ instance. To
 build upon the generated app, modify the project by adding logic and additional
 files to the folders outlined above. You can visit the
 [control-menu-entry](/docs/7-1/reference/-/knowledge_base/r/control-menu-entry)
-sample project for a more expanded sample of a Control Menu entry. Likewise, see
-the
-[Customizing the Control Menu](/docs/7-2/customization/-/knowledge_base/c/customizing-the-control-menu)
-tutorial for instructions on customizing a Control Menu entry project.
+sample project for a more expanded sample of a Control Menu entry. 

--- a/developer/reference/articles/project-templates/panel-app-template.markdown
+++ b/developer/reference/articles/project-templates/panel-app-template.markdown
@@ -91,6 +91,10 @@ Gradle-specific files, but otherwise, appears exactly the same.
 The generated module is functional and is deployable to a @product@ instance.
 The generated module, by default, creates a panel category with a panel app in
 @product@'s Product Menu. To build upon the generated app, modify the project by
-adding logic and additional files to the folders outlined above. You can visit
-the [Customizing the Product Menu](/docs/7-2/customization/-/knowledge_base/c/customizing-the-product-menu)
+adding logic and additional files to the folders outlined above. 
+
+<!--Uncomment once article is available
+You can visit the 
+Customizing the Product Menu
 tutorial for instructions on customizing a panel app project.
+-->

--- a/developer/reference/articles/project-templates/simulation-panel-entry-template.markdown
+++ b/developer/reference/articles/project-templates/simulation-panel-entry-template.markdown
@@ -85,7 +85,11 @@ The generated module is functional and is deployable to a @product@ instance. To
 build upon the generated app, modify the project by adding logic and additional
 files to the folders outlined above. You can visit the
 [simulation-panel-app](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/apps/simulation-panel-app)
-sample project for a more expanded sample of a control menu entry. Likewise, see
+sample project for a more expanded sample of a control menu entry. 
+
+<!--Uncomment once article is available
+Likewise, see
 the
-[Extending the Simulation Menu](/docs/7-2/customization/-/knowledge_base/c/extending-the-simulation-menu)
+Extending the Simulation Menu
 tutorial for instructions on customizing a simulation panel entry project.
+-->

--- a/developer/reference/articles/project-templates/template-context-contributor-template.markdown
+++ b/developer/reference/articles/project-templates/template-context-contributor-template.markdown
@@ -83,5 +83,5 @@ files to the folders outlined above. You can visit the
 [template-context-contributor](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/themes/template-context-contributor)
 sample project for a more expanded sample of a template context contributor.
 Likewise, see the
-[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-into-your-templates)
+[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
 tutorial for instructions on customizing a template context contributor project.

--- a/developer/reference/articles/sample-projects/01-intro.markdown
+++ b/developer/reference/articles/sample-projects/01-intro.markdown
@@ -50,7 +50,7 @@ logging is implemented for several samples (e.g.,
 [service-builder/jdbc](/docs/7-2/reference/-/knowledge_base/r/service-builder-application-using-external-database-via-jdbc),
 etc.), which lets OSGi modules supply their own logging configuration defaults
 without external configuration. See the
-[Adjusting Module Logging](/docs/7-2/customization/-/knowledge_base/c/adjusting-module-logging)
+[Adjusting Module Logging](/docs/7-2/appdev/-/knowledge_base/a/adjusting-module-logging)
 article for more information.
 
 For a list of sample template projects available, visit the

--- a/developer/reference/articles/sample-projects/02-apps/kotlin-portlet.markdown
+++ b/developer/reference/articles/sample-projects/02-apps/kotlin-portlet.markdown
@@ -21,11 +21,12 @@ interface.
 
 ## How does this sample leverage the API(s) and/or code component?
 
-This sample uses the
-[MVC Action Command](/docs/7-2/appdev/-/knowledge_base/a/mvc-action-command)'s
-`processAction(...)` method to process the inputted text (i.e., name). The text
-is set as an attribute in the `KotlinGreeterActionCommandKt.kt` class using an
-`ActionRequest` and then is retrieved in the JSP using a `RenderRequest`.
+This sample uses the MVC Action Command's `processAction(...)` method to process 
+the inputted text (i.e., name). The text is set as an attribute in the 
+`KotlinGreeterActionCommandKt.kt` class using an `ActionRequest` and then is 
+retrieved in the JSP using a `RenderRequest`. 
+
+<!-- Add back link for 'MVC Action Command' once mvc-action-command article is available-->
 
 ## Where Is This Sample?
 

--- a/developer/reference/articles/sample-projects/02-apps/shared-language-keys.markdown
+++ b/developer/reference/articles/sample-projects/02-apps/shared-language-keys.markdown
@@ -96,7 +96,7 @@ republishing an aggregate `ResourceBundleLoader`. This can be done two ways:
     the modules referencing them to recognize their updates.
 
 For more information on sharing language keys, visit the
-[Internationalization](/docs/7-2/frameworks/-/knowledge_base/f/internationalization)
+[Internationalization](/docs/7-2/frameworks/-/knowledge_base/f/localization)
 tutorials.
 
 ## Where Is This Sample?

--- a/developer/reference/articles/sample-projects/02-apps/simulation-panel-app.markdown
+++ b/developer/reference/articles/sample-projects/02-apps/simulation-panel-app.markdown
@@ -55,12 +55,14 @@ interface with JSP support. JSPs, however, are not the only way to provide
 frontend functionality to your panel categories/apps. You can create your own
 class implementing `PanelApp` to use other technologies, such as FreeMarker.
 
+<!--Uncomment once articles are available
 To learn more about Liferay Portal's product navigation using panel categories
 and panel apps, see the
-[Customizing the Product Menu](/docs/7-2/customization/-/knowledge_base/c/customizing-the-product-menu)
+Customizing the Product Menu
 tutorial. For more information on extending the Simulation Menu, see the
-[Extending the Simulation Menu](/docs/7-2/customization/-/knowledge_base/c/extending-the-simulation-menu)
+Extending the Simulation Menu
 tutorial.
+-->
 
 ## Where Is This Sample?
 

--- a/developer/reference/articles/sample-projects/03-extensions/control-menu-entry.markdown
+++ b/developer/reference/articles/sample-projects/03-extensions/control-menu-entry.markdown
@@ -57,10 +57,14 @@ The following methods are implemented:
 - `isShow(HttpServletRequest)`
 
 Refer to this sample's `BladeProductNavigationControlMenuEntry` class for
-Javadocs describing these methods. For more information on how to customize
+Javadocs describing these methods. 
+
+<!--Uncomment once article is available
+For more information on how to customize
 Liferay Portal's Control Menu, visit the
-[Customizing the Control Menu](/docs/7-2/customization/-/knowledge_base/c/customizing-the-control-menu)
+Customizing the Control Menu
 tutorial.
+-->
 
 ## Where Is This Sample?
 

--- a/developer/reference/articles/sample-projects/05-themes/template-context-contributor.markdown
+++ b/developer/reference/articles/sample-projects/05-themes/template-context-contributor.markdown
@@ -45,7 +45,7 @@ fit your needs, see the Javadoc listed in this sample's
 `com.liferay.blade.samples.theme.contributorBladeTemplateContextContributor`
 class. For more information on context contributors and how to create them in
 @product@, visit the
-[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme)
+[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
 tutorial.
 
 ## Where Is This Sample?

--- a/developer/reference/articles/tooling/blade-cli/04-managing-your-liferay-server-with-blade-cli.markdown
+++ b/developer/reference/articles/tooling/blade-cli/04-managing-your-liferay-server-with-blade-cli.markdown
@@ -67,7 +67,7 @@ modifying a Liferay server:
     ![Figure 1: Blade CLI accesses the Gogo shell script to run the `lb` command.](../../../images/blade-sh.png)
 
     You can run any Gogo command using `blade sh`. This command requires
-    [Developer Mode](/docs/7-2/frameworks/-/knowledge_base/f/using-developer-mode-with-themes#setting-developer-mode-for-your-server-using-portal-developer-properties)
+    [Developer Mode](/docs/7-2/frameworks/-/knowledge_base/f/using-developer-mode-with-themes)
     to be enabled. Developer Mode is enabled in workspace by default. See the
     [Using the Felix Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/using-the-felix-gogo-shell)
     section for more information on this tool.

--- a/developer/reference/articles/tooling/dev-studio/06-using-the-gogo-shell-in-dev-studio.markdown
+++ b/developer/reference/articles/tooling/dev-studio/06-using-the-gogo-shell-in-dev-studio.markdown
@@ -28,7 +28,7 @@ feature.
     ![Figure 2: You can check to see if your project deployed successfully to Liferay using the Gogo shell.](../../../images/gogo-deploy-successful.png)
 
 **Important:** Dev Studio's Gogo shell usage requires
-[Developer Mode](/docs/7-2/frameworks/-/knowledge_base/f/using-developer-mode-with-themes#setting-developer-mode-for-your-server-in-liferay-ide)
+[Developer Mode](/docs/7-2/frameworks/-/knowledge_base/f/using-developer-mode-with-themes)
 to be enabled. Developer Mode is enabled in
 [Liferay Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace)
 by default.

--- a/developer/reference/articles/tooling/liferay-workspace/03-creating-a-liferay-workspace.markdown
+++ b/developer/reference/articles/tooling/liferay-workspace/03-creating-a-liferay-workspace.markdown
@@ -106,7 +106,7 @@ A dialog appears prompting you to open the Liferay Workspace perspective. Click
     ![Figure 3: Choose *Liferay Gradle Workspace* or *Liferay Maven Workspace*, depending on the build you prefer.](../../../images/intellij-workspace-build.png)
 
 4.  Specify your workspace's name, location, intended @product@ version,
-    [target platform](/docs/7-2/reference/-/knowledge_base/r/managing-the-target-platform-for-liferay-workspace),
+    [target platform](/docs/7-2/reference/-/knowledge_base/r/managing-the-target-platform),
     and SDK (i.e., Java JDK). Then click *Finish*.
 
     ![Figure 4: Specify your workspace's configurations.](../../../images/intellij-workspace-project.png)

--- a/developer/reference/articles/tooling/liferay-workspace/10-managing-the-target-platform/01-intro.markdown
+++ b/developer/reference/articles/tooling/liferay-workspace/10-managing-the-target-platform/01-intro.markdown
@@ -13,7 +13,7 @@ are updated to the latest ones provided in the targeted release.
 
 | **Note:** There are times when configuring dependencies based on a version
 | range is better than tracking exact versions. See the
-| [Semantic Versioning](/docs/7-2/reference/-/knowledge_base/r/semantic-versioning)
+| [Semantic Versioning](/docs/7-2/customization/-/knowledge_base/c/semantic-versioning)
 | tutorial for more details.
 
 Next, you'll discover how all of this is possible.

--- a/developer/reference/articles/tooling/liferay-workspace/11-validating-modules-against-the-target-platform/01-intro.markdown
+++ b/developer/reference/articles/tooling/liferay-workspace/11-validating-modules-against-the-target-platform/01-intro.markdown
@@ -127,9 +127,9 @@ resolver to bypass this.
 
 There are three ways you can do this:
 
-- [Embed the third party library in your module](/docs/7-2/reference/-/knowledge_base/r/adding-third-party-libraries-to-a-module#embedding-libraries-in-a-module)
+- [Embed the third party library in your module](/docs/7-2/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module)
 - [Add the third party library's capabilities to the current static set of resolver capabilities](/docs/7-2/reference/-/knowledge_base/r/adding-a-third-party-librarys-capabilities-to-the-resolvers-capabilities)
-- [Skip the resolving process for your module](/docs/7-2/reference/-/knowledge_base/r/skipping-the-resolving-process-for-your-module)
+- [Skip the resolving process for your module](/docs/7-2/reference/-/knowledge_base/r/skipping-the-resolving-process-for-a-module)
 
 | **Note:** You should only embed a third party library in your module if it's
 | the only module that depends on it. You should not bypass the resolver failure

--- a/developer/reference/articles/tooling/liferay-workspace/11-validating-modules-against-the-target-platform/06-how-to-resolve-common-output-errors-reported-by-the-resolve-task.markdown
+++ b/developer/reference/articles/tooling/liferay-workspace/11-validating-modules-against-the-target-platform/06-how-to-resolve-common-output-errors-reported-by-the-resolve-task.markdown
@@ -9,7 +9,7 @@ header-id: how-to-resolve-common-output-errors-reported-by-the-resolve-task
 Liferay Workspace provides the `resolve` Gradle task to validate modules. This
 is very useful for finding issues and reporting them as output before
 deployment. For general help with OSGi related issues, visit the
-[Troubleshooting FAQ](/docs/7-2/reference/-/knowledge_base/r/troubleshooting)
+[Troubleshooting FAQ](/docs/7-2/appdev/-/knowledge_base/a/troubleshooting-application-development-issues)
 section.
 
 For help interpreting the `resolve` task's output, see the list below for common
@@ -38,14 +38,14 @@ dependencies cannot be satisfied. These types of scenarios are difficult to
 diagnose, but with the `resolve` task, can be found with ease.
 
 To fix missing import errors, you may need to adjust the
-[export](/docs/7-2/reference/-/knowledge_base/r/exporting-packages) and/or
-[import](/docs/7-2/reference/-/knowledge_base/r/importing-packages)
+[export](/docs/7-2/customization/-/knowledge_base/c/exporting-packages) and/or
+[import](/docs/7-2/customization/-/knowledge_base/c/importing-packages)
 configuration of your modules. Also, see the
-[Resolving Third Party Library Package Dependencies](/docs/7-2/reference/-/knowledge_base/r/adding-third-party-libraries-to-a-module)
+[Resolving Third Party Library Package Dependencies](/docs/7-2/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module)
 tutorial for more information on resolving import errors. Sometimes, this kind
 of error can be solved by editing the `resolve` task's list of capabilities. See
 the
-[Resolving Third Party Library Package Dependencies](/docs/7-2/reference/-/knowledge_base/r/adding-third-party-libraries-to-a-module)
+[Resolving Third Party Library Package Dependencies](/docs/7-2/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module)
 section to learn how to do this.
 
 ## Missing Service Reference
@@ -130,5 +130,5 @@ Once you know the correct BSN/version to reference, update your `Fragment-Host`
 header to resolve the error.
 
 For more information on fragments, see the
-[JSP Overrides Using OSGi Fragments](/docs/7-2/customization/-/knowledge_base/c/overriding-a-modules-jsps)
+[JSP Overrides Using OSGi Fragments](/docs/7-2/customization/-/knowledge_base/c/jsp-overrides-using-osgi-fragments)
 tutorial.

--- a/developer/reference/articles/tooling/liferay-workspace/12-leveraging-docker/01-intro.markdown
+++ b/developer/reference/articles/tooling/liferay-workspace/12-leveraging-docker/01-intro.markdown
@@ -44,6 +44,6 @@ In this section, you'll learn how to
 
 - [Create a Docker container based on a provided @product@ image](/docs/7-2/reference/-/knowledge_base/r/creating-a-product-docker-container).
 - [Configure the container](/docs/7-2/reference/-/knowledge_base/r/configuring-a-docker-container).
-- [Build a custom image](/docs/7-2/reference/-/knowledge_base/r/building-a-custom-product-image).
+- [Build a custom image](/docs/7-2/reference/-/knowledge_base/r/building-a-custom-docker-image).
 
 Continue on to learn more.

--- a/developer/reference/articles/tooling/maven/07-building-an-osgi-module-jar-with-maven.markdown
+++ b/developer/reference/articles/tooling/maven/07-building-an-osgi-module-jar-with-maven.markdown
@@ -57,7 +57,7 @@ Continue on to see how this is done.
     | **Note:** Although WABs can be generated using the `bnd-maven-plugin`,
     | this is not supported by Liferay. WABs should be created as a standard WAR
     | project and deployed to the
-    | [Liferay WAB Generator](/docs/7-2/reference/-/knowledge_base/r/using-the-wab-generator),
+    | [Liferay WAB Generator](/docs/7-2/customization/-/knowledge_base/c/deploying-wars-wab-generator),
     | which generates a WAB for you.
 
 2.  In your project's `pom.xml` file, add the

--- a/developer/reference/articles/tooling/maven/08-building-themes-in-a-maven-project.markdown
+++ b/developer/reference/articles/tooling/maven/08-building-themes-in-a-maven-project.markdown
@@ -9,7 +9,7 @@ header-id: building-a-theme-with-maven
 Liferay's Theme Builder is used to build @product@ theme files in your project.
 You can incorporate the Theme Builder into your Maven project to generate
 WAR-style
-[themes](/docs/7-2/frameworks/-/knowledge_base/f/themes-and-layout-templates)
+[themes](/docs/7-2/frameworks/-/knowledge_base/f/themes-introduction)
 deployable to @product@.
 
 The easiest way to create a Liferay theme with Maven is to create a new Maven

--- a/developer/reference/articles/tooling/maven/10-using-service-builder-in-a-maven-project.markdown
+++ b/developer/reference/articles/tooling/maven/10-using-service-builder-in-a-maven-project.markdown
@@ -7,11 +7,11 @@ header-id: using-service-builder-in-a-maven-project
 [TOC levels=1-4]
 
 The easiest way to add
-[Service Builder](/develop/frameworks/-/knowledge_base/7-2/what-is-service-builder)
+[Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
 to your Maven project is to create a new Maven project using Liferay's provided
 Service Builder archetype; it's configured in the new project by default. You
 can learn how to generate a Service Builder Maven project by visiting the
-[Service Builder Template](/docs/7-2/reference/-/knowledge_base/r/service-builder-template)
+[Service Builder Template](/docs/7-2/reference/-/knowledge_base/r/using-the-service-builder-template)
 article.
 
 In some cases, you should not use this template due to a number of reasons:
@@ -67,11 +67,15 @@ project!
     directory name, model hints file, Spring configurations, SQL configurations,
     etc. You can reference all the configurable Service Builder properties in
     the
-    [Service Builder Plugin](/docs/7-2/reference/-/knowledge_base/r/service-builder-with-maven)
-    reference article. Also, visit the
-    [Defining an Object-Relational Map with Service Builder](/docs/7-2/frameworks/-/knowledge_base/f/defining-an-object-relational-map-with-service-builder)
+    [Service Builder Plugin](/docs/7-2/reference/-/knowledge_base/r/service-builder-plugin)
+    reference article. 
+    
+    <!--Uncomment once article is available
+    Also, visit the
+    Defining an Object-Relational Map with Service Builder
     tutorial for more information on defining a `service.xml` file to configure
     Service Builder.
+    -->
 
 2.  Apply the WSDD Builder plugin declaration directly after the Service Builder
     plugin declaration:
@@ -90,15 +94,23 @@ project!
     ```
 
     The WSDD Builder is required to generate your project's remote services.
+    
+    <!--Uncomment once article is available
     Visit the
-    [Creating Remote Services](/docs/7-2/frameworks/-/knowledge_base/f/creating-remote-services)
+    Creating Remote Services
     tutorial for more information on WSDD (Web Service Deployment Descriptor).
+    -->
+    
     See the
     [WSDD Builder Plugin](/docs/7-2/reference/-/knowledge_base/r/wsdd-builder-plugin)
     article for more information on the configuration properties.
 
 Terrific! You've successfully configured your Maven project to use Service
 Builder by applying the Service Builder and WSDD Builder plugins in your
-project's POM. To run Service Builder, see the
-[Running Service Builder and Understanding the Generated Code](/docs/7-2/frameworks/-/knowledge_base/f/running-service-builder)
+project's POM. 
+
+<!--Uncomment once article is available
+To run Service Builder, see the
+Running Service Builder and Understanding the Generated Code
 article for instructions.
+-->

--- a/developer/reference/articles/tooling/maven/99-upgrading-your-maven-build-environment.markdown
+++ b/developer/reference/articles/tooling/maven/99-upgrading-your-maven-build-environment.markdown
@@ -160,7 +160,7 @@ Liferay Portal 6.2 Artifact ID | @product-ver@ Artifact ID |
 `util-taglib` | `com.liferay.util.taglib` |
 
 For more information on resolving dependencies in @product-ver@, see the
-[Resolving a Plugin's Dependencies](/docs/7-2/tutorials/-/knowledge_base/t/resolving-a-plugins-dependencies)
+[Resolving a Plugin's Dependencies](/docs/7-2/customization/-/knowledge_base/c/configuring-dependencies)
 article.
 
 Of course, you must also update the artifacts you're referencing for your


### PR DESCRIPTION
fixed, but note that errors are still thrown for the three links below, even though they are fixed:

```
check-links:
[checklinks] 1. **INVALID URL**
[checklinks]  File: ..\reference\articles\gradle-plugins\app-docker-gradle-plugin.markdown:85
[checklinks]  Line: [`pushAppDockerImage_${tag}`](#tasks-pushappdockerimage-) | `tagAppDockerImage_${tag}` | [`DockerPushImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html) | Pushes the Docker image `${tag}` to the registry.
[checklinks]
[checklinks] 2. **INVALID URL**
[checklinks]  File: ..\reference\articles\gradle-plugins\app-docker-gradle-plugin.markdown:86
[checklinks]  Line: [`tagAppDockerImage_${tag}`](#tasks-tagappdockerimage-) | `buildAppDockerImage` | [`DockerTagImage`](http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/DockerTagImage.html) | Creates the tag `${tag}`, which refers to the app's Docker image.
[checklinks]
[checklinks] 3. **INVALID URL**
[checklinks]  File: ..\reference\articles\sample-projects\02-apps\greedy-policy-option-portlet.markdown:166
[checklinks]  Line: [*Deploying a module with a higher ranked service instance for binding to greedy references immediately*](#deploying-a-module-with-a-higher-ranked-service-instance-for-binding-to-greedy-references-immediately)
[checklinks]
```