### PR TITLE
LRDOCS-7052 fix broken links in tutorials

### DIFF
--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/01-intro.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/01-intro.markdown
@@ -44,7 +44,7 @@ Here are the code upgrade steps:
             Import an existing Liferay Workspace. If you don't have one, revisit
             the previous step.{.summary}
 
-    2.  [Configure Liferay Workspace Settings](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-your-development-environment#configuring-liferay-workspace){.title}
+    2.  [Configure Liferay Workspace Settings](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-your-development-environment#configuring-liferay-workspace-settings){.title}
 
         Set the @product@ version in workspace's configuration you intend to
         upgrade to.{.summary}
@@ -93,7 +93,7 @@ Here are the code upgrade steps:
         Update your Workspace plugin version to leverage the latest features of
         Liferay Workspace.{.summary}
 
-    3.  [Remove Dependency Versions](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-build-dependencies#removing-the-projects-dependency-versions){.title commandId=remove_dependency_version}
+    3.  [Remove Dependency Versions](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-build-dependencies#removing-your-projects-build-dependency-versions){.title commandId=remove_dependency_version}
 
         Remove the project's dependency versions since it's leveraging target
         platform.{.summary}
@@ -163,7 +163,7 @@ Here are the code upgrade steps:
 
     9.  [Upgrade Servlet Filter Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-servlet-filter-hooks){.title}
 
-    10. [Upgrade Portal Properties Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-override-extension-hooks){.title}
+    10. [Upgrade Portal Properties Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-portal-property-hooks){.title}
 
     11. [Upgrade Struts Action Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-struts-action-hooks){.title}
 
@@ -214,9 +214,11 @@ Here are the code upgrade steps:
 
     4.  [Upgrade Servlet-based Portlets](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-servlet-based-portlet){.title}
 
-    5.  [Migrate from Spring Portlet MVC to PortletMVC4Spring](/docs/7-2/tutorials/-/knowledge_base/t/migrating-from-spring-portlet-mvc-to-portletmvc4spring){.title}
+<!--Uncomment once article is available
+    5.  Migrate from Spring Portlet MVC to PortletMVC4Spring {.title}
+-->
 
-    6.  [Upgrade Struts 1 Portlets](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-struts-1-portlet){.title}
+    5.  [Upgrade Struts 1 Portlets](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-struts-1-portlet){.title}
 
 11. [Upgrade Web Plugins](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-web-plugins){.title}
 

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/02-resolving-a-projects-dependencies.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/02-resolving-a-projects-dependencies.markdown
@@ -103,7 +103,7 @@ You can use @product@'s
 [App Manager](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts#finding-liferay-portal-app-and-independent-artifacts),
 [Felix Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/using-the-felix-gogo-shell),
 or
-[module JAR file manifests](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts#finding-core-liferay-portal-artifacts)
+[module JAR file manifests](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts#finding-core-liferay-portal-artifact-attributes)
 to find versions of modules deployed on your @product@ instance. 
 
 For more information on resolving your project's dependencies, see the

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/03-resolving-breaking-changes.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/03-resolving-breaking-changes.markdown
@@ -32,7 +32,7 @@ Liferay provides a list of breaking changes for every major release to ensure
 you can easily adapt your code during the upgrade process.
 
 - [@product@ 7.0 Breaking Changes](/docs/7-0/reference/-/knowledge_base/r/breaking-changes)
-- [@product@ 7.1 Breaking Changes](/docs/7-1/reference/7-1/-/knowledge_base/r/breaking-changes)
+- [@product@ 7.1 Breaking Changes](/docs/7-1/reference/-/knowledge_base/r/breaking-changes)
 - [@product-ver@ Breaking Changes](/docs/7-2/reference/-/knowledge_base/r/breaking-changes)
 
 The easiest way to resolve breaking changes is by using the

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/06-upgrading-service-builder-services/03-converting-a-service-builder-module-from-spring-di-to-osgi-ds.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/06-upgrading-service-builder-services/03-converting-a-service-builder-module-from-spring-di-to-osgi-ds.markdown
@@ -87,8 +87,10 @@ steps:
 2.  Replace all the `@ServiceReference` and `@BeanReference` field annotations 
     with the DS `@Reference` annotation. 
     
-3.  [Run Service Builder](/docs/7-2/appdev/-/knowledge_base/a/running-service-builder)
-    to regenerate the interfaces based on your implementation changes. 
+3.  Run Service Builder to regenerate the interfaces based on your 
+    implementation changes. 
+
+    <!--Add back link to 'Run Service Builder' once running-service-builder article is available-->
 
 4.  Replace the following methods:
 
@@ -116,11 +118,11 @@ dependencies.
     in step 3.1. 
 
     - Run `system:check` in
-      [Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/felix-gogo-shell)
+      [Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/using-the-felix-gogo-shell)
       to detect obvious circular dependencies.
     
     - Run `scr:info [component]` in the
-      [Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/felix-gogo-shell)
+      [Gogo Shell](/docs/7-2/customization/-/knowledge_base/c/using-the-felix-gogo-shell)
       to examine components and determine the best places to break circular
       dependencies.
 
@@ -129,9 +131,5 @@ Congratulations on converting your service module to use Declarative Services.
 ## Related Topics 
 
 [Service Builder](/docs/7-2/appdev/-/knowledge_base/a/service-builder)
-
-[Understanding the Code Service Builder Generates](/docs/7-2/appdev/-/knowledge_base/a/understanding-the-code-generated-by-service-builder)
-
-[Spring Dependency Injection](/docs/7-2/frameworks/-/knowledge_base/f/spring-dependency-injection)
 
 [Declarative Services](/docs/7-2/frameworks/-/knowledge_base/f/declarative-services)

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/06-upgrading-service-builder-services/04-rebuilding-services.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/06-upgrading-service-builder-services/04-rebuilding-services.markdown
@@ -14,9 +14,10 @@ To properly upgrade Service Builder projects, you must rebuild all service
 classes so your changes are persisted across your project. Initiate this step
 to rebuild your services and finalize your Service Builder upgrade.
 
+<!--Uncomment once article is available
 To run Service Builder outside the Liferay Upgrade Planner, see the
-[Running Service Builder](/docs/7-2/appdev/-/knowledge_base/a/running-service-builder)
-article. This covers running Service Builder with Blade CLI, Gradle, Maven, and
-Dev Studio.
+Running Service Builder article. This covers running Service Builder with Blade 
+CLI, Gradle, Maven, and Dev Studio.
+-->
 
 Great! Your Service Builder services are upgraded!

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/01-intro.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/01-intro.markdown
@@ -11,7 +11,7 @@ plugins to them takes very few steps. In most cases, after you upgrade your hook
 using the Liferay Upgrade Planner, it's ready to run on @product@. The following
 tutorials show you how to upgrade each type of hook plugin.
 
-- [Override/Extension Modules](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-overrideextension-modules)
+- [Override/Extension Modules](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-customization-modules)
 - [Core JSP Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-core-jsp-hooks)
 - [Portlet JSP Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-portlet-jsp-hooks)
 - [Service Wrapper Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-service-wrapper-hooks)
@@ -20,7 +20,7 @@ tutorials show you how to upgrade each type of hook plugin.
 - [Model Listener Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-model-listener-hooks)
 - [Event Actions Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-event-action-hooks)
 - [Servlet Filter Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-servlet-filter-hooks)
-- [Portal Properties Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-portal-properties-hooks)
+- [Portal Properties Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-portal-property-hooks)
 - [Struts Action Hooks](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-struts-action-hooks)
 
 Continue on to get started!

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/02-upgrading-jndi-data-source-usage.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/02-upgrading-jndi-data-source-usage.markdown
@@ -16,5 +16,5 @@ JNDI data source without using @product@'s class loader results in a
 `java.lang.ClassNotFoundException`.
 
 For more information on how to do this, see the
-[Connecting to JNDI Data Sources](/docs/7-2/customization/-/knowledge_base/c/connecting-to-jndi-data-sources)
+[Connecting to JNDI Data Sources](/docs/7-2/appdev/-/knowledge_base/a/connecting-to-data-sources-using-jndi)
 article.

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/03-upgrading-service-builder-service-invocation.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/03-upgrading-service-builder-service-invocation.markdown
@@ -22,10 +22,10 @@ modularizing it.
 
 If you prefer keeping your Service Builder logic as a WAR, you must implement a
 service tracker to call services. See the
-[Service Trackers](/docs/7-2/customization/-/knowledge_base/c/service-trackers)
+[Service Trackers](/docs/7-2/frameworks/-/knowledge_base/f/using-a-service-tracker)
 article for more information.
 
+<!--Uncomment once article is available
 If you're optimizing your Service Builder logic to invoke Liferay services from
-a module, see the
-[Invoking Local Services](/docs/7-2/appdev/-/knowledge_base/a/invoking-local-services)
-article for more information.
+a module, see the Invoking Local Services article for more information.
+-->

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/04-upgrading-service-builder.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/04-upgrading-service-builder.markdown
@@ -69,9 +69,9 @@ tutorial. Once your dependencies are upgraded, rebuild your services!
 
 ## Step 3: Build the Services
 
-To rebuild your portlet's services, see the
-[Running Service Builder](/docs/7-2/appdev/-/knowledge_base/a/running-service-builder)
-article.
+<!--Uncomment once article is available
+To rebuild your portlet's services, see the Running Service Builder article.
+-->
 
 An example change where upgrading legacy Service Builder code can produce
 differing results is explained below.

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/05-migrating-off-of-velocity-templates.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/10-upgrading-frameworks-and-features/05-migrating-off-of-velocity-templates.markdown
@@ -24,5 +24,5 @@ this move:
 
 Although Velocity templates still work in @product-ver@, we highly recommend
 migrating to FreeMarker templates. For more information on this topic, see the
-[Upgrading Layout Templates](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-layout-templates)
+[Upgrading Layout Templates](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-layout-template-to-7-2)
 section.

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/11-upgrading-portlets/01-intro.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/11-upgrading-portlets/01-intro.markdown
@@ -25,8 +25,11 @@ portlets:
 -   [Liferay MVC Portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-liferay-mvc-portlet)
 -   [Liferay JSF Portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-liferay-jsf-portlet)
 -   [Servlet-based portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-servlet-based-portlet)
--   [Spring MVC Portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-spring-mvc-portlet)
--   [Struts Portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-struts-portlet)
+-   [Struts Portlet](/docs/7-2/tutorials/-/knowledge_base/t/upgrading-a-struts-1-portlet)
+
+<!--Uncomment once article is available
+-   Spring MVC Portlet
+-->
 
 Let's get your portlet running on @product-ver@!
 

--- a/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/13-upgrading-ext-plugins.markdown
+++ b/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/13-upgrading-ext-plugins.markdown
@@ -27,5 +27,5 @@ points.
 
 For more information on Ext projects, how to decide if you need one, and how to
 manage them, see the
-[Customization with Ext](/docs/7-2/reference/-/knowledge_base/r/customization-with-ext)
+[Customization with Ext](/docs/7-2/customization/-/knowledge_base/c/customization-with-ext)
 section.


### PR DESCRIPTION
@jhinkey here is the last portion of broken links. The two hased routes still throw errors though, even though they work on the site:

```
check-links:
[checklinks] 1. **INVALID URL**
[checklinks]  File: ..\tutorials\articles\03-upgrading-code-to-liferay-7.2\05-fixing-upgrade-problems\02-resolving-a-projects-dependencies.markdown:103
[checklinks]  Line: [App Manager](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts#finding-liferay-portal-app-and-independent-artifacts),
[checklinks]
[checklinks] 2. **INVALID URL**
[checklinks]  File: ..\tutorials\articles\03-upgrading-code-to-liferay-7.2\05-fixing-upgrade-problems\02-resolving-a-projects-dependencies.markdown:106
[checklinks]  Line: [module JAR file manifests](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts#finding-core-liferay-portal-artifact-attributes)
[checklinks]
```