### PR TITLE
LRDOCS-7229 Explain why micro changes are optional

### DIFF
--- a/deployment/articles-dxp/06-maintaining-liferay/01-patching-liferay-dxp/02-patching-basics/01-patching-basics-intro.markdown
+++ b/deployment/articles-dxp/06-maintaining-liferay/01-patching-liferay-dxp/02-patching-basics/01-patching-basics-intro.markdown
@@ -21,7 +21,8 @@ fixes address regressions or obvious bugs and don't require you to make
 additional changes. Each fix pack contains all previous fix packs since the last
 service pack. 
 
-**Note:** *Micro* upgrade changes are optional data changes in Liferay DXP fix packs. 
+**Note:** *Micro* upgrade changes are optional data changes in Liferay DXP fix packs
+since these modifications are not mandatory for the code to work.
 
 You can use the [upgrade
 tool](/docs/7-2/deploy/-/knowledge_base/d/upgrading-to-product-ver) to execute

--- a/deployment/articles-dxp/06-maintaining-liferay/01-patching-liferay-dxp/02-patching-basics/01-patching-basics-intro.markdown
+++ b/deployment/articles-dxp/06-maintaining-liferay/01-patching-liferay-dxp/02-patching-basics/01-patching-basics-intro.markdown
@@ -21,6 +21,24 @@ fixes address regressions or obvious bugs and don't require you to make
 additional changes. Each fix pack contains all previous fix packs since the last
 service pack. 
 
+**Note:** *Micro* upgrade changes are optional data changes in Liferay DXP fix packs. 
+
+You can use the [upgrade
+tool](/docs/7-2/deploy/-/knowledge_base/d/upgrading-to-product-ver) to execute
+core micro upgrades whenever you want. Before using the upgrade tool to execute
+a fix pack's micro upgrade process, however, you must shut down the server,
+install the fix pack, and [back up the @product@ database, installation, and
+Document Library
+store](/docs/7-2/deploy/-/knowledge_base/d/backing-up-a-liferay-installation).
+
+To prevent module micro upgrades from running automatically, set
+`autoUpgrade="false"` in a file called
+`com.liferay.portal.upgrade.internal.configuration.ReleaseManagerConfiguration.config`
+and copy the file into the `[Liferay Home]/osgi/configs` folder. You can [use
+Gogo shell to run module
+upgrades](/docs/7-2/deploy/-/knowledge_base/d/upgrading-modules-using-gogo-shell)
+whenever you want.
+
 Fixes that don't fit these requirements are considered for service packs or hot
 fixes. 
 

--- a/deployment/articles/05-upgrading-to-liferay-7-2/01-upgrading-to-liferay-7-2-intro.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/01-upgrading-to-liferay-7-2-intro.markdown
@@ -26,7 +26,8 @@ Here are the installation upgrade paths:
 **Note:** *Micro* upgrade changes are data changes in Liferay DXP fix packs or
 data changes in GA release for the same minor version of Liferay Portal CE
 (e.g., installing Liferay Portal CE 7.2 GA2 on a 7.2 GA1 installation). Micro
-upgrade changes are optional in Liferay DXP 7.1+ and Liferay Portal CE 7.2+.
+upgrade changes are optional in Liferay DXP 7.1+ and Liferay Portal CE 7.2+
+since the code doesn't require this data modifications. 
 
 You can use the upgrade tool (discussed later) to execute core micro upgrades
 whenever you want.

--- a/deployment/articles/05-upgrading-to-liferay-7-2/01-upgrading-to-liferay-7-2-intro.markdown
+++ b/deployment/articles/05-upgrading-to-liferay-7-2/01-upgrading-to-liferay-7-2-intro.markdown
@@ -23,6 +23,22 @@ Here are the installation upgrade paths:
 | **Note:** Liferay Portal 6.0+ *code* can be upgraded directly to @product@ 
 | 7.2.
 
+**Note:** *Micro* upgrade changes are data changes in Liferay DXP fix packs or
+data changes in GA release for the same minor version of Liferay Portal CE
+(e.g., installing Liferay Portal CE 7.2 GA2 on a 7.2 GA1 installation). Micro
+upgrade changes are optional in Liferay DXP 7.1+ and Liferay Portal CE 7.2+.
+
+You can use the upgrade tool (discussed later) to execute core micro upgrades
+whenever you want.
+
+To prevent module micro upgrades from running automatically, set
+`autoUpgrade="false"` in a file called
+`com.liferay.portal.upgrade.internal.configuration.ReleaseManagerConfiguration.config`
+and copy the file into the `[Liferay Home]/osgi/configs` folder. You can [use
+Gogo shell to run module
+upgrades](/docs/7-2/deploy/-/knowledge_base/d/upgrading-modules-using-gogo-shell)
+(discussed later) whenever you want. 
+
 Here are the upgrade steps: 
 
 | **Note:** You can 


### PR DESCRIPTION
Hey @jhinkey,

I have explained why micro changes are optional.

Apart from this, I miss an article highlighting the news in 7.2+ updating between GAs. From now, CE users won't need to execute the upgrade tool prior to moving to the next GA! They just need to follow these steps:

- Download the bundle or install the files in your server.
- [Optional] Check release notes to verify if you could need to execute the micro upgrade processes first. If you don't want to execute it, disable autoUpgrade so module upgrades won't run on startup.
- Startup the server pointing out to your previous database and document library.

Don't you think it can be useful?

Thanks.