### PR TITLE
7.0.x branch - LPS-75089 Add a dependency from ROOT.war to the data source in jboss-web.xml file

### DIFF
--- a/discover/deployment/articles/02-installing-liferay/05-installing-liferay-on-wildfly.markdown
+++ b/discover/deployment/articles/02-installing-liferay/05-installing-liferay-on-wildfly.markdown
@@ -339,6 +339,23 @@ Your final data sources subsystem should look like this:
             </datasources>
         </subsystem>
 
+3.  Add a dependency from ROOT.war to your data source inside 
+    `$WILDFLY_HOME/standalone/deployments/ROOT.war/WEB-INF/jboss-web.xml` file's 
+    `<jboss-web>` element:
+
+    ```xml
+    <resource-ref>
+        <res-ref-name>jboss/datasources/ExampleDS</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>
+    </resource-ref>
+    ```
+
+    This will tell application server that Liferay is using the data source, so it 
+    must not be closed until Liferay is stopped. For more information, see 
+    [jboss-web.xml documentation](https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html/administration_and_configuration_guide/naming_on_jboss-j2ee_and_jndi___the_application_component_environment#ENC_Usage_Conventions-Resource_Manager_Connection_Factory_References_with_jboss.xml_and_jboss_web.xml)
+
 Now that you've configured your data source, the mail session is next. 
 
 ## Mail Configuration


### PR DESCRIPTION
In https://issues.liferay.com/browse/LPS-75089 some errors were detected during Liferay shutdown in case you configure Liferay in Wildfly/JBoss with JNDI datasource.

After some investigations, it seems it was a configuration problem. It is necessary to modify jboss-web.xml but it is not specified in official documentation.

I am updating the documentation, explaining the missing modification:
 - master changes: https://github.com/jhinkey/liferay-docs/pull/493
 - 7.1 changes: https://github.com/jhinkey/liferay-docs/pull/494
 - 7.0 changes: https://github.com/jhinkey/liferay-docs/pull/495