### PR TITLE
update links in upgrading code liferay 7.2

### DIFF
--- a/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/02-resolving-a-projects-dependencies.markdown
+++ b/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/05-fixing-upgrade-problems/02-resolving-a-projects-dependencies.markdown
@@ -61,7 +61,7 @@ identifying the module and specifying your project's dependency on it.
 Before @product@ 7.0, all the platform APIs were in `portal-service.jar`. Many 
 of these APIs are now in independent modules. Modularization has resulted in 
 many benefits, as described in the article 
-[Benefits of @product-ver@ for Liferay Portal 6 Developers](/docs/tutorials/7-1/-/knowledge_base/t/benefits-of-liferay-7-for-liferay-6-developers#modular-development-paradigm). 
+[Benefits of @product-ver@ for Liferay Portal 6 Developers](/docs/7-1/tutorials/-/knowledge_base/t/benefits-of-liferay-7-for-liferay-6-developers#modular-development-paradigm). 
 One such advantage is that these API modules can evolve separately from the
 platform kernel. They also simplify future upgrades. For example, instead of
 having to check all of Liferay's APIs, each module's 

--- a/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/05-upgrading-service-wrapper-hooks.markdown
+++ b/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/05-upgrading-service-wrapper-hooks.markdown
@@ -11,7 +11,7 @@ header-id: upgrading-service-wrapper-hooks
 </div>
 
 Upgrading traditional
-[service wrapper hook plugins](/docs/tutorials/6-2/-/knowledge_base/t/overriding-a-portal-service-using-a-hook)
+[service wrapper hook plugins](/docs/6-2/tutorials/-/knowledge_base/t/overriding-a-portal-service-using-a-hook)
 to @product-ver@ is quick and easy.
 
 1.  Adapt your code to @product-ver@'s API using the Liferay Upgrade Planner. When

--- a/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/12-upgrading-struts-action-hooks.markdown
+++ b/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/07-upgrading-customization-plugins/12-upgrading-struts-action-hooks.markdown
@@ -56,7 +56,7 @@ shown below:
 -   `serveResource` &rarr; [`MVCResourceCommand`](@platform-ref@/7.2-latest/javadocs/portal-kernel/com/liferay/portal/kernel/portlet/bridges/mvc/MVCResourceCommand.html)
 
 Look at the
-[`ExampleStrutsPortletAction` class](/docs/tutorials/6-2/-/knowledge_base/t/overriding-and-adding-struts-actions)
+[`ExampleStrutsPortletAction` class](/docs/6-2/tutorials/-/knowledge_base/t/overriding-and-adding-struts-actions)
 for a `StrutsAction` wrapper example. Depending on the actions overridden, the
 user must use different `MVCCommand`s. In this example, the action and render
 were overridden, so to migrate to the new pattern, you would create two classes:

--- a/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/11-upgrading-portlets/05-upgrading-a-servlet-based-portlet.markdown
+++ b/en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/11-upgrading-portlets/05-upgrading-a-servlet-based-portlet.markdown
@@ -46,7 +46,7 @@ many third party packages for plugins to use. Best practices for using packages
 that @product@ exports are found
 [here](/docs/7-2/customization/-/knowledge_base/c/configuring-dependencies). For
 more information on this specific scenario, see the
-[Using Packages Liferay Portal Exports](/docs/tutorials/7-1/-/knowledge_base/t/resolving-a-plugins-dependencies#using-packages-liferay-portal-exports)
+[Using Packages Liferay Portal Exports](/docs/7-1/tutorials/-/knowledge_base/t/resolving-a-plugins-dependencies#using-packages-liferay-portal-exports)
 section.
 
 Once you've deployed your portlet, the server prints messages that indicate the


### PR DESCRIPTION
Hello @jhinkey,

I've updated some links, could you help review when you're available? And still have one more problem needs your help:

In line 15 of the following file, I can't find the lunar-resort-theme-migration-6.2.zip file, where can we download it?
en/developer/tutorials/articles/03-upgrading-code-to-liferay-7.2/08-upgrading-themes/02-upgrading-6.2-themes-7.2/01-upgrading-6.2-themes-to-7.1-intro.markdown
```
Font Awesome icons and Bootstrap. The theme [ZIP file](/documents/10184/656312/lunar-resort-theme-migration-6.2.zip) 
contains its original source code. 
```

Thanks